### PR TITLE
Changing dependencies. Connect, ConnectWithOptions, CreateTable, and CreateTableWithOptions breaking changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.csv
+cpu.prof
 main.go

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inquiry is a Go package that converts CSV files into a SQLite database, allowing
 
 ## How to use
 
-Using Inquiry is pretty simple: You "connect" to the CSV file and Inquiry will return a `*sql.DB` and a `[]error`. You can then use the returned `*sql.DB` to do any operations that you would normally do with a SQLite database.
+Using Inquiry is pretty simple: You "connect" to the CSV file and Inquiry will return a `*sql.DB` and an `error`. You can then use the returned `*sql.DB` to do any operations that you would normally do with a SQLite database.
 
 You can also create new tables from CSV files and add them to an existing SQLite database (in-memory or not). 
 
@@ -80,13 +80,9 @@ type Example struct {
 }
 
 func main() {
-    // 'errs' is a []error with a cap of 25. If there are no errors, then 'errs' will be nil.
-    db, errs := inquiry.Connect[Example]("example.csv")
-    if errs != nil {
-        for _, e := range errs {
-            log.Println(e.Error())
-        }
-        os.Exit(1)
+    db, err := inquiry.Connect[Example]("example.csv")
+    if err != nil {
+        log.Fatalln(err.Error())
     }
     // Don't forget to close the database.
     defer db.Close()
@@ -159,14 +155,10 @@ func main() {
         Delimiter:    '|',
         HasHeaderRow: true,
     }
-
-    // 'errs' is a []error with a cap of 25. If there are no errors, then 'errs' will be nil.
-    db, errs := inquiry.ConnectWithOptions[Example]("example.csv", options)
-    if errs != nil {
-        for _, e := range errs {
-            log.Println(e.Error())
-        }
-        os.Exit(1)
+    
+    db, err := inquiry.ConnectWithOptions[Example]("example.csv", options)
+    if err != nil {
+        log.Fatalln(err.Error())
     }
     // Don't forget to close the database.
     defer db.Close()
@@ -252,25 +244,17 @@ func main() {
         Delimiter:    '|',
         HasHeaderRow: true,
     }
-
-    // 'errs' is a []error with a cap of 25. If there are no errors, then 'errs' will be nil.
-    db, errs := inquiry.ConnectWithOptions[Example]("example.csv", options)
-    if errs != nil {
-        for _, e := range errs {
-            log.Println(e.Error())
-        }
-        os.Exit(1)
+    
+    db, err := inquiry.ConnectWithOptions[Example]("example.csv", options)
+    if err != nil {
+        log.Fatalln(err.Error())
     }
     // Don't forget to close the database.
     defer db.Close()
-
-    // 'errs' is a []error with a cap of 25. If there are no errors, then 'errs' will be nil.
-    errs = inquiry.CreateTable[Test](db, "test.csv")
-    if errs != nil {
-        for _, e := range errs {
-            log.Println(e.Error())
-        }
-        os.Exit(1)
+    
+    err = inquiry.CreateTable[Test](db, "test.csv")
+    if err != nil {
+        log.Fatalln(err.Error())
     }
 
     rows, err := db.Query("SELECT * FROM Example WHERE Value > 80 ORDER BY Name ASC;")
@@ -342,8 +326,7 @@ import (
     "log"
     "os"
 
-    _ "github.com/ncruces/go-sqlite3/driver"
-    _ "github.com/ncruces/go-sqlite3/embed"
+    _ "github.com/mattn/go-sqlite3"
     "github.com/sionpixley/inquiry/pkg/inquiry"
 )
 
@@ -370,14 +353,10 @@ func main() {
         Delimiter:    ';',
         HasHeaderRow: false,
     }
-
-    // 'errs' is a []error with a cap of 25. If there are no errors, then 'errs' will be nil.
-    errs := inquiry.CreateTableWithOptions[Test](db, "test.csv", options)
-    if errs != nil {
-        for _, e := range errs {
-            log.Println(e.Error())
-        }
-        os.Exit(1)
+    
+    err = inquiry.CreateTableWithOptions[Test](db, "test.csv", options)
+    if err != nil {
+        log.Fatalln(err.Error())
     }
 
     rows, err := db.Query("SELECT * FROM Example WHERE Value > 80 ORDER BY Name ASC;")

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,4 @@ module github.com/sionpixley/inquiry
 
 go 1.24.1
 
-require github.com/ncruces/go-sqlite3 v0.24.0
-
-require (
-	github.com/ncruces/julianday v1.0.0 // indirect
-	github.com/tetratelabs/wazero v1.9.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-)
+require github.com/mattn/go-sqlite3 v1.14.24

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,2 @@
-github.com/ncruces/go-sqlite3 v0.24.0 h1:Z4jfmzu2NCd4SmyFwLT2OmF3EnTZbqwATvdiuNHNhLA=
-github.com/ncruces/go-sqlite3 v0.24.0/go.mod h1:/Vs8ACZHjJ1SA6E9RZUn3EyB1OP3nDQ4z/ar+0fplTQ=
-github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
-github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
-github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
-github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/pkg/inquiry/helpers.go
+++ b/pkg/inquiry/helpers.go
@@ -73,7 +73,7 @@ func createTable[T any](db *sql.DB) (reflect.Type, error) {
 	return t, err
 }
 
-func insert(row []string, tx *sql.Tx, t reflect.Type) error {
+func insert(tx *sql.Tx, row []string, t reflect.Type) error {
 	if t.Kind() != reflect.Struct {
 		return errors.New(_NOT_A_STRUCT_ERROR)
 	}
@@ -95,7 +95,7 @@ func insert(row []string, tx *sql.Tx, t reflect.Type) error {
 	return err
 }
 
-func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Type) (*sql.DB, error) {
+func insertRows(db *sql.DB, csvFilePath string, t reflect.Type, options CsvOptions) (*sql.DB, error) {
 	if _, err := os.Stat(csvFilePath); os.IsNotExist(err) {
 		return nil, errors.New(_FILE_PATH_DOES_NOT_EXIST_ERROR)
 	} else if err != nil {
@@ -136,7 +136,7 @@ func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Ty
 				return nil, err
 			}
 
-			err = insert(row, tx, t)
+			err = insert(tx, row, t)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/inquiry/helpers.go
+++ b/pkg/inquiry/helpers.go
@@ -95,26 +95,25 @@ func insert(row []string, tx *sql.Tx, t reflect.Type) error {
 	return err
 }
 
-func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Type) (*sql.DB, []error) {
+func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Type) (*sql.DB, error) {
 	if _, err := os.Stat(csvFilePath); os.IsNotExist(err) {
-		return nil, []error{errors.New(_FILE_PATH_DOES_NOT_EXIST_ERROR)}
+		return nil, errors.New(_FILE_PATH_DOES_NOT_EXIST_ERROR)
 	} else if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	file, err := os.Open(csvFilePath)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 	defer file.Close()
 
 	tx, err := db.Begin()
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 	defer tx.Rollback()
 
-	errs := []error{}
 	reader := csv.NewReader(file)
 	if int(options.Delimiter) != 0 {
 		reader.Comma = options.Delimiter
@@ -126,7 +125,7 @@ func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Ty
 			if err == io.EOF {
 				break
 			} else if err != nil {
-				return nil, []error{err}
+				return nil, err
 			}
 			options.HasHeaderRow = false
 		} else {
@@ -134,25 +133,19 @@ func insertRows(db *sql.DB, csvFilePath string, options CsvOptions, t reflect.Ty
 			if err == io.EOF {
 				break
 			} else if err != nil {
-				return nil, []error{err}
+				return nil, err
 			}
 
 			err = insert(row, tx, t)
 			if err != nil {
-				if len(errs) < 25 {
-					errs = append(errs, err)
-				}
+				return nil, err
 			}
 		}
 	}
 
-	if len(errs) > 0 {
-		return nil, errs
-	}
-
 	err = tx.Commit()
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	return db, nil

--- a/pkg/inquiry/inquiry.go
+++ b/pkg/inquiry/inquiry.go
@@ -40,7 +40,7 @@ func ConnectWithOptions[T any](csvFilePath string, options CsvOptions) (*sql.DB,
 		return nil, err
 	}
 
-	return insertRows(db, csvFilePath, options, t)
+	return insertRows(db, csvFilePath, t, options)
 }
 
 /*
@@ -64,6 +64,6 @@ func CreateTableWithOptions[T any](db *sql.DB, csvFilePath string, options CsvOp
 		return err
 	}
 
-	_, errs := insertRows(db, csvFilePath, options, t)
+	_, errs := insertRows(db, csvFilePath, t, options)
 	return errs
 }

--- a/pkg/inquiry/inquiry.go
+++ b/pkg/inquiry/inquiry.go
@@ -4,8 +4,7 @@ package inquiry
 import (
 	"database/sql"
 
-	_ "github.com/ncruces/go-sqlite3/driver"
-	_ "github.com/ncruces/go-sqlite3/embed"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 // CsvOptions is a struct that allows you to configure information about your CSV file.
@@ -16,31 +15,29 @@ type CsvOptions struct {
 
 /*
 Connect is a function that creates an in-memory SQLite database from a CSV file.
-It takes the CSV file path as a parameter and returns two things: A pointer to the in-memory SQLite database
-and an error slice with the errors that happened during the creation of the database (cap of 25).
-If no errors occur, the returned error slice will be nil.
+It takes the CSV file path as a parameter and returns two things: A pointer to the in-memory SQLite database and an error.
+If no errors occur, the returned error will be nil.
 
 It assumes that the CSV file doesn't have a header row and that the file's delimiter is a comma.
 If you need to customize these, please use the function ConnectWithOptions.
 */
-func Connect[T any](csvFilePath string) (*sql.DB, []error) {
+func Connect[T any](csvFilePath string) (*sql.DB, error) {
 	return ConnectWithOptions[T](csvFilePath, CsvOptions{Delimiter: ',', HasHeaderRow: false})
 }
 
 // ConnectWithOptions is a function that creates an in-memory SQLite database from a CSV file.
 // It takes two parameters: the CSV file path and a CsvOptions struct.
-// It returns two things: A pointer to the in-memory SQLite database
-// and an error slice with the errors that happened during the creation of the database (cap of 25).
-// If no errors occur, the returned error slice will be nil.
-func ConnectWithOptions[T any](csvFilePath string, options CsvOptions) (*sql.DB, []error) {
+// It returns two things: A pointer to the in-memory SQLite database and an error.
+// If no errors occur, the returned error will be nil.
+func ConnectWithOptions[T any](csvFilePath string, options CsvOptions) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	t, err := createTable[T](db)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	return insertRows(db, csvFilePath, options, t)
@@ -49,24 +46,22 @@ func ConnectWithOptions[T any](csvFilePath string, options CsvOptions) (*sql.DB,
 /*
 CreateTable is a function that creates a new table from a CSV file and adds it to an existing SQLite database.
 It takes two parameters: a pointer to the SQLite database and a CSV file path.
-It returns an error slice with the errors that happened during the creation of the table (cap of 25).
-If no errors occur, the returned error slice will be nil.
+It returns an error. If no errors occur, the returned error will be nil.
 
 It assumes that the CSV file doesn't have a header row and that the file's delimiter is a comma.
 If you need to customize these, please use the function CreateTableWithOptions.
 */
-func CreateTable[T any](db *sql.DB, csvFilePath string) []error {
+func CreateTable[T any](db *sql.DB, csvFilePath string) error {
 	return CreateTableWithOptions[T](db, csvFilePath, CsvOptions{Delimiter: ',', HasHeaderRow: false})
 }
 
 // CreateTableWithOptions is a function that creates a new table from a CSV file and adds it to an existing SQLite database.
 // It takes three parameters: a pointer to the SQLite database, a CSV file path, and a CsvOptions struct.
-// It returns an error slice with the errors that happened during the creation of the table (cap of 25).
-// If no errors occur, the returned error slice will be nil.
-func CreateTableWithOptions[T any](db *sql.DB, csvFilePath string, options CsvOptions) []error {
+// It returns an error. If no errors occur, the returned error will be nil.
+func CreateTableWithOptions[T any](db *sql.DB, csvFilePath string, options CsvOptions) error {
 	t, err := createTable[T](db)
 	if err != nil {
-		return []error{err}
+		return err
 	}
 
 	_, errs := insertRows(db, csvFilePath, options, t)


### PR DESCRIPTION
No longer using [ncruces/go-sqlite3](https://github.com/ncruces/go-sqlite3) as the SQLite driver. Switching to [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) for performance reasons. This means that CGO is required, however. Additionally, `Connect`, `ConnectWithOptions`, `CreateTable`, and `CreateTableWithOptions` now return an `error` instead of a `[]error`.